### PR TITLE
fix bug in egg-decorate-log (substring args out of range)

### DIFF
--- a/egg.el
+++ b/egg.el
@@ -5,6 +5,7 @@
 ;; Copyright (C) 2008  Marius Vollmer
 ;; Copyright (C) 2009  Tim Moore
 ;; Copyright (C) 2009  byplayer
+;; Copyright (C) 2010  Alexander Prusov
 ;;
 ;; Egg is free software; you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by
@@ -3192,6 +3193,7 @@ If INIT was not nil, then perform 1st-time initializations as well."
   (set (make-local-variable 'egg-log-msg-diff-beg) nil))
 
 (define-key egg-log-msg-mode-map (kbd "C-c C-c") 'egg-log-msg-done)
+(define-key egg-log-msg-mode-map (kbd "C-c C-k") 'egg-log-msg-cancel)
 (define-key egg-log-msg-mode-map (kbd "M-p") 'egg-log-msg-older-text)
 (define-key egg-log-msg-mode-map (kbd "M-n") 'egg-log-msg-newer-text)
 (define-key egg-log-msg-mode-map (kbd "C-l") 'egg-buffer-cmd-refresh)
@@ -3231,6 +3233,12 @@ If INIT was not nil, then perform 1st-time initializations as well."
 	  (if (windowp win) (egg-quit-buffer win))))
     (message "Please enter a log message!")
     (ding)))
+
+(defun egg-log-msg-cancel ()
+  (interactive)
+  (if (> (length (window-list)) 1)
+      (delete-window)
+    (kill-buffer)))
 
 (defun egg-log-msg-hist-cycle (&optional forward)
   "Cycle through message log history."
@@ -3333,7 +3341,7 @@ If INIT was not nil, then perform 1st-time initializations as well."
 		    (t "Shit happens!"))
 	      "\n"
 	      "Repository: " (egg-text git-dir 'font-lock-constant-face) "\n"
-	      (egg-text "--------------- Commit Message (type C-c C-c when done) ---------------"
+	      (egg-text "-- Commit Message (type `C-c C-c` when done or `C-c C-k` when cancel) -"
 			'font-lock-comment-face))
       (put-text-property (point-min) (point) 'read-only t)
       (put-text-property (point-min) (point) 'rear-sticky nil)


### PR DESCRIPTION
if `lref` less 4, substring throws error and function don't work.
