### PR TITLE
Fix for when git repo is under a symlink

### DIFF
--- a/egg.el
+++ b/egg.el
@@ -615,7 +615,7 @@ Return the output lines as a list of strings."
 (defsubst egg-buf-git-name (&optional buf)
   "return the repo-relative name of the file visited by BUF.
 if BUF was nil then use current-buffer"
-  (egg-file-git-name (buffer-file-name buf)))
+  (egg-file-git-name (file-truename (buffer-file-name buf))))
 
 (defsubst egg-files-git-name (files)
   "return the repo-relative name for each file in the list of files FILES."


### PR DESCRIPTION
If the git repo is under a symlink (say, its canonical location is /foo/bar, but /home/user/foo is a symlink to /foo) and you open a file from the symlinked location (i.e., /home/user/foo/bar/somefile), the git commands will fail as buffer-file-name returns /home/user/foo/bar/somefile, but git barfs since it's being run from /foo/bar. This change makes sure that egg-buf-git-name wraps the buffer-file-name output with file-truename.
