### PR TITLE
bugfix for staging new files

### DIFF
--- a/egg.el
+++ b/egg.el
@@ -2487,7 +2487,7 @@ rebase session."
 
 (defun egg-status-buffer-stage-untracked-file ()
   (interactive)
-  (let ((file (ffap-file-at-point)))
+  (let ((file (buffer-substring-no-properties (line-beginning-position) (line-end-position))))
     (when (egg-sync-do-file file egg-git-command nil nil
                             (list "add" "--" file))
       (message "new file %s added" file))))


### PR DESCRIPTION
the original function ffap-file-at-point returned nil for filenames like Import - test.launch.
now the whole line is used instead
