### PR TITLE
Made the mode compatible with package.el's format

### DIFF
--- a/egg-grep.el
+++ b/egg-grep.el
@@ -1,6 +1,7 @@
-;;; egg -- Emacs Got Git
-;;; A magit fork
-
+;;; egg-grep.el -- Emacs Got Git's compile-mode which can grep files in non-checkout git revisions
+;; 
+;; A magit fork
+;; 
 ;; Copyright (C) 2008  Linh Dang
 ;;
 ;; Egg is free software; you can redistribute it and/or modify it
@@ -130,3 +131,4 @@ Set up `compilation-exit-message-function' and run `egg-grep-setup-hook'."
 		       `(lambda (name) 
 			  (format "*git-grep@%s*" ,git-dir)))))
 
+;;; egg-grep.el ends here

--- a/egg.el
+++ b/egg.el
@@ -1,12 +1,18 @@
 ;;; egg -- Emacs Got Git
-;;; A magit fork
-
+;;
+;; A magit fork
+;; 
 ;; Copyright (C) 2008  Linh Dang
 ;; Copyright (C) 2008  Marius Vollmer
 ;; Copyright (C) 2009  Tim Moore
 ;; Copyright (C) 2010  Alexander Prusov
 ;; Copyright (C) 2011  byplayer
-;;
+;; 
+;; Author: Bogolisk <bogolisk@gmail.com>
+;; Created: 19 Aug 2008
+;; Version: 1.0.2
+;; Keywords: git, version control, release management
+;; 
 ;; Special Thanks to
 ;;   Antoine Levitt, Bogolisk,
 ;;   Christian Köstlin
@@ -6205,3 +6211,5 @@ egg in current buffer.\\<egg-minor-mode-map>
 
 (run-hooks 'egg-load-hook)
 (provide 'egg)
+
+;;; egg.el ends here


### PR DESCRIPTION
Added the formatting so that the it can be easier to package this mode
for MELPA, Marmelade ...

The format is described here:

http://marmalade-repo.org/doc-files/package.5.html

I'd like to create a recipe for this mode, and nothing is currently stopping me from doing so, but when I do do it, the description for the package is missing. It would be great if this wasn't so, as I think that Egg is a great mode for Git interaction, lots of helpful little parts and this is one way of bringing it to a wider audience :)

Thanks
