### PR TITLE
Please apply bugfixe for persistent hunk range for 3-way and adding symlinks

### DIFF
--- a/egg.el
+++ b/egg.el
@@ -2674,9 +2674,15 @@ the section.
   "Return the 4 numbers from hunk header as list of integers"
   (destructuring-bind (file hunk-header hunk-beg &rest ignore)
       (egg-hunk-info-at pos)
-    (let* ((range (save-match-data
-                    (split-string hunk-header "[ @,\+,-]+" t))))
-      (mapcar 'string-to-number range))))
+    (let* ((range-as-strings
+            (save-match-data
+              (split-string hunk-header "[ @,\+,-]+" t)))
+           (range
+            (mapcar 'string-to-number range-as-strings)))
+      (if (/= 6 (length range))
+          range
+        (append (subseq range 0 2)
+                  (subseq range 4))))))
 
 (defun egg-ensure-hunk-ranges-cache ()
   "Returns `egg-hunk-ranges-cache' re-creating it if its NIL."
@@ -2713,10 +2719,10 @@ the section.
             (real-range (third elem))
             (single-range (fourth elem)))
         (when (eq sect 'unstaged)
-          (destructuring-bind (l1 s1 l2 s2) range
+          (destructuring-bind (l1 s1 l2 &optional s2) range
             (when (< l2 line)
               ;; Increment adjustment by how many lines were added
-              (incf cnt (- s2 s1)))))))
+              (incf cnt (- (or s2 s1) s1)))))))
     cnt))
 
 (defun egg-staged-lines-delta-before-hunk (file line)
@@ -2728,10 +2734,10 @@ the section.
             (real-range (third elem))
             (single-range (fourth elem)))
         (when (eq sect 'staged)
-          (destructuring-bind (l1 s1 l2 s2) range
+          (destructuring-bind (l1 s1 l2 &optional s2) range
             (when (< l2 line)
               ;; Increment adjustment by how many lines were added
-              (incf cnt (- s2 s1)))))))
+              (incf cnt (- (or s2 s1) s1)))))))
     cnt))
 
 (defun egg-calculate-hunk-ranges ()


### PR DESCRIPTION
Fix errors with persistent hunk ranges when working with 3-way diffs, and adding symbolic links
- egg.el (egg-get-hunk-range): Handle 6 number hunk header range that happens in 3-way diffs
  (egg-unstaged-lines-delta-before-hunk): Handle 3 number range (happens on adding symlinks)
  (egg-staged-lines-delta-before-hunk): ditto
