### PR TITLE
Fix for issue #41 - persistent hunk ranges when adding sub-modules.

### DIFF
--- a/egg.el
+++ b/egg.el
@@ -2694,7 +2694,7 @@ the section.
        ((= 4 len) range)
        ;; 3 way diff when merging, never seen >6
        ((= 6 len) (append (subseq range 0 2)
-                          (subseq range 4 2)))
+                          (subseq range 4 6)))
        ;; Adding sub-modules
        ((= 2 len) (append range range))
        ;; Adding symbolic links
@@ -2709,7 +2709,7 @@ the section.
        (t (warn "Weird hunk header %S" hunk-header)
           ;; treat as 6 line one
           (append (subseq range 0 2)
-                  (subseq range 4 2)))))))
+                  (subseq range 4 6)))))))
 
 (defun egg-ensure-hunk-ranges-cache ()
   "Returns `egg-hunk-ranges-cache' re-creating it if its NIL."


### PR DESCRIPTION
- (egg-get-hunk-range): Normalize hunk range no matter how many line
  numbers it contains
