### PR TITLE
Stage multiple untracked files

### DIFF
--- a/egg.el
+++ b/egg.el
@@ -2539,7 +2539,8 @@ untracked files"
         (unless (string= files "")
           (message "new files added: %s" files)))
     ;; act only on single files
-    (let ((file (ffap-file-at-point)))
+    (let ((file (buffer-substring-no-properties
+                 (line-beginning-position) (line-end-position))))
       (when (egg-sync-do-file file egg-git-command nil nil
                               (list "add" "--" file))
         (message "new file %s added" file)))))


### PR DESCRIPTION
Previously, when in **Egg-Status** buffer, the untracked files could be added to the repo one by one, by placing the cursor over the untracked file and pressing **s**.

With this addition, the names of untracked files can be selected as a region, and by pressing **s**, all the highlighted files will be staged.

Please consider merging this in.

Thanks for your time
