### PR TITLE
Autoloads

### DIFF
--- a/egg.el
+++ b/egg.el
@@ -6559,24 +6559,24 @@ egg in current buffer.\\<egg-minor-mode-map>
 ;;;###autoload
 (defun egg-minor-mode-find-file-hook ()
   (when (egg-is-in-git)
-    (make-local-variable 'egg-minor-mode)
-    (egg-minor-mode 1)))
+    (when (string-match "\\`git version 1.\\(6\\|7\\)."
+                        (shell-command-to-string
+                         (concat egg-git-command " --version")))
+      (or (assq 'egg-minor-mode minor-mode-alist)
+          (setq minor-mode-alist
+                (cons '(egg-minor-mode egg-minor-mode-name) minor-mode-alist)))
+      (setcdr (or (assq 'egg-minor-mode minor-mode-map-alist)
+                  (car (setq minor-mode-map-alist
+                             (cons (list 'egg-minor-mode)
+                                   minor-mode-map-alist))))
+              egg-minor-mode-map)
+      (make-local-variable 'egg-minor-mode)
+      (egg-minor-mode 1))))
 
-(when (string-match "\\`git version 1.\\(6\\|7\\)."
-		    (shell-command-to-string
-		     (concat egg-git-command " --version")))
-  (or (assq 'egg-minor-mode minor-mode-alist)
-      (setq minor-mode-alist
-            (cons '(egg-minor-mode egg-minor-mode-name) minor-mode-alist)))
-
-  (setcdr (or (assq 'egg-minor-mode minor-mode-map-alist)
-              (car (setq minor-mode-map-alist
-                         (cons (list 'egg-minor-mode)
-                               minor-mode-map-alist))))
-          egg-minor-mode-map)
-
-  (add-hook 'find-file-hook 'egg-git-dir)
-  (add-hook 'find-file-hook 'egg-minor-mode-find-file-hook))
+;;;###autoload
+(add-hook 'find-file-hook 'egg-git-dir)
+;;;###autoload
+(add-hook 'find-file-hook 'egg-minor-mode-find-file-hook)
 
 ;;;========================================================
 ;;; tool-tip


### PR DESCRIPTION
I think that SHA:  9ae5b190daa162e9bc67bc07e30254a35b168301 was created when there were Git version which were not compatible with Egg's approach.

The reason I created this pull request, is because when [MELPA](http://melpa.milkbox.net/) would create Egg package, it would create egg-autoloads.el which would be picked up on Emacs' start up. This is all fine, but because hooks where wrapped in in **(when ...)**, they wouldn't be seen and in turn **egg-minor-mode** wouldn't be activated.

Please consider merging this in.

Thank you
