### PR TITLE
Fixed the name of the package

### DIFF
--- a/egg.el
+++ b/egg.el
@@ -1,12 +1,10 @@
-;;; egg.el -- Emacs Got Git
-;;
-;; A magit fork
-;;
+;;; egg.el --- Emacs Got Git - Emacs interface to Git
+
 ;; Copyright (C) 2008  Linh Dang
 ;; Copyright (C) 2008  Marius Vollmer
 ;; Copyright (C) 2009  Tim Moore
 ;; Copyright (C) 2010  Alexander Prusov
-;; Copyright (C) 2011  byplayer
+;; Copyright (C) 2011-12 byplayer
 ;;
 ;; Author: Bogolisk <bogolisk@gmail.com>
 ;; Created: 19 Aug 2008


### PR DESCRIPTION
My original intention was to update just the missing '**-**' so that the package name would conform to the Emacs [package naming conventions](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html). Because when [MELPA](http://melpa.milkbox.net/) currently lists egg.el it shows it as:

```
egg 20120612    No description available.
```

due to the missing '**-**'.

But then I thought why not remove the bit about 'magit fork' as the original author of the Magit package is credited and the README mentions Magit as well.

Also updated the copyright years.
