### PR TITLE
Use filename instead of relative path to undo checkout

### DIFF
--- a/egg.el
+++ b/egg.el
@@ -7055,7 +7055,7 @@ That's the CONFIRM-P paramter in non-interactive use."
         (error "File %s contains unstaged changes!" file)))
     (setq egg--do-no-output-message (format "checked out %s's contents from index" file))
     (egg-file-buffer-handle-result
-     (egg--git-co-files-cmd (egg-get-status-buffer) git-file))))
+     (egg--git-co-files-cmd (egg-get-status-buffer) file))))
 
 (defun egg-start-new-branch (&optional force)
   "Start a new branch from HEAD."


### PR DESCRIPTION
I get this whenever I use C-x C-v u to undo the checkout of a file I've modified I get

GIT-CHECKOUT:ERROR> error: pathspec 'lib/tasks/db.rake' did not match any file(s) known to git.

With this change it works. It appears as though the full path from the top of the repo doesn't work because the git command is run from the directory where the buffer is. So it needs just the filename in that directory. 
