### PR TITLE
Default user.name and user.email

### DIFF
--- a/egg-git.el
+++ b/egg-git.el
@@ -677,10 +677,14 @@ if EXTRAS contains :error-if-not-git then error-out if not a git repo.
 	    
 	    ((eq req :name)
              (setq state
-                   (nconc (list :name (egg-git-to-string "config" "user.name")) state)))
+                   (nconc (list :name (or (egg-git-to-string "config" "user.name")
+                                          (capitalize (user-login-name))))
+                          state)))
 	    ((eq req :email)
              (setq state
-                   (nconc (list :email (egg-git-to-string "config" "user.email")) state)))))
+                   (nconc (list :email (or (egg-git-to-string "config" "user.email")
+                                           (concat (user-login-name) "@" (system-name))))
+                          state)))))
     ;; update mode-line
     (egg-set-mode-info state)
     state))


### PR DESCRIPTION
`egg-commit-log-edit` is failing if there's no either `user.name` or `user.email` specified in `.gitconfig`.
We can use some default values e.g. login name if  there's no `user.name`, and `login-name@hostname` if `user.email` is missing.
BTW, `git commit` does the same in this case.
